### PR TITLE
Implementation of highlights to navic and neotree

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
   - [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim)
   - [indent-blankline.nvim](https://github.com/lukas-reineke/indent-blankline.nvim)
   - [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
+  - [nvim-navic](https://github.com/SmiteshP/nvim-navic/tree/master)
+  - [nvim-neo-tree](https://github.com/nvim-neo-tree/neo-tree.nvim)
 - Support for various terminal emulators (see [`term/`](term/)):
   - [Alacritty](https://github.com/alacritty/alacritty)
   - [Foot](https://codeberg.org/dnkl/foot)

--- a/colors/melange.lua
+++ b/colors/melange.lua
@@ -275,6 +275,15 @@ local highlight_groups = {
   texMathDelim = 'Delimiter',
   texMathEnvArgName = 'PreProc',
 
+  --- neo-tree highlights  :help neo-tree-highlights ---
+
+  NeoTreeNormal = { bg = pallete.a.float, fg = pallete.a.fg },
+  NeoTreeNormalNC = 'NeoTreeNormal',
+  NeoTreeVertSplit = { bg = pallete.a.bg, fg = pallete.a.bg },
+  NeoTreeWinSeparator = 'NeoTreeVertSplit',
+
+  NeoTreeCursorLine = { bg = pallete.a.sel },
+
   --- netrw: there's no comprehensive list of highlights... --
 
   netrwClassify = 'Delimiter',

--- a/colors/melange.lua
+++ b/colors/melange.lua
@@ -107,7 +107,6 @@ local highlight_groups = {
   Comment = { fg = a.com, italic = italic },
   Identifier = { fg = a.fg },
   Function = { fg = b.yellow },
-
   Constant = { fg = c.magenta },
   String = { fg = b.blue, italic = italic },
   Character = { fg = c.blue },
@@ -283,6 +282,37 @@ local highlight_groups = {
   NeoTreeWinSeparator = 'NeoTreeVertSplit',
 
   NeoTreeCursorLine = { bg = pallete.a.sel },
+
+  --- nvim navic icon highlights  :help navic-highlights ---
+
+  NavicIconsFile = "Identifier",
+  NavicIconsModule = "PreProc",
+  NavicIconsNamespace = "PreProc",
+  NavicIconsPackage = "PreProc",
+  NavicIconsClass = "PreProc",
+  NavicIconsMethod = "Function",
+  NavicIconsProperty = "Constant",
+  NavicIconsField = "Constant",
+  NavicIconsConstructor = "PreProc",
+  NavicIconsEnum = "PreProc",
+  NavicIconsInterface = "PreProc",
+  NavicIconsFunction = "Function",
+  NavicIconsVariable = "PreProc",
+  NavicIconsConstant = "Constant",
+  NavicIconsString = "String",
+  NavicIconsNumber = "Number",
+  NavicIconsBoolean = "Boolean",
+  NavicIconsArray = "Delimeter",
+  NavicIconsObject = "Delimeter",
+  NavicIconsKey = "Delimeter",
+  NavicIconsNull = "Number",
+  NavicIconsEnumMember = "Delimeter",
+  NavicIconsStruct = "PreProc",
+  NavicIconsEvent = "PreProc",
+  NavicIconsOperator = "Operator",
+  NavicIconsTypeParameter = "Delimeter",
+  NavicText = "Identifier",
+  NavicSeparator = "Delimeter",
 
   --- netrw: there's no comprehensive list of highlights... --
 


### PR DESCRIPTION
## Checklist for Plugins <!-- Remove if PR is for terminal emulator -->

This PR adds highlights to the [neo-tree](https://github.com/nvim-neo-tree/neo-tree.nvim/blob/main/doc/neo-tree.txt) and [nvim-navic](https://github.com/SmiteshP/nvim-navic/blob/master/doc/navic.txt) plugins.

- [x] (In `colors/melange.lua`) Add highlight groups
- [x] (In `README.md`) Add link to plugin source repository

--------------------------------------------------------------------------------
<!-- If there's any additional information you consider relevant, write it here. -->

Here are a few screenshots I took showing off how the highlights I chose look:

<table>
  <tr>
    <td><img src="https://github.com/savq/melange-nvim/assets/88866334/59e88f2f-af28-47ac-9240-a11cab1fc9ae" alt="Screenshot for neo-tree"></td>
    <td><img src="https://github.com/savq/melange-nvim/assets/88866334/668bcd0a-e04a-4e51-87e4-b6200255d052" alt="Screenshot for nvim-navic"></td>
  </tr>
</table>