### PR TITLE
Update highlight groups for indent-blankline

### DIFF
--- a/colors/melange.lua
+++ b/colors/melange.lua
@@ -330,6 +330,8 @@ for name, attrs in pairs {
   IndentBlanklineChar = { fg = a.sel, nocombine = true },
   IndentBlanklineSpaceChar = 'IndentBlanklineChar',
   IndentBlanklineSpaceCharBlankline = 'IndentBlanklineChar',
+  IblIndent = { fg = a.sel, nocombine = true },
+  IblWhitespace = 'IblIndent',
 } do
   if type(attrs) == 'table' then
     vim.api.nvim_set_hl(0, name, attrs)


### PR DESCRIPTION
## Checklist for Plugins <!-- Remove if PR is for terminal emulator -->

https://github.com/lukas-reineke/indent-blankline.nvim/blob/0ac5dfe835ec0f201ef6af17d4737d43b4bfce0d/doc/indent_blankline.txt#L833

- [x] (In `colors/melange.lua`) Add highlight groups
- [ ] (In `README.md`) Add link to plugin source repository

--------------------------------------------------------------------------------

New highlight groups for indent-blankline v3.