### PR TITLE
Add cmp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   - [neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim)
   - [lightline.vim](https://github.com/itchyny/lightline.vim)
   - [lualine.nvim](https://github.com/nvim-lualine/lualine.nvim)
+  - [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
 - Support for various terminal emulators (see [`term/`](term/)):
   - [Alacritty](https://github.com/alacritty/alacritty)
   - [Foot](https://codeberg.org/dnkl/foot)

--- a/colors/melange.lua
+++ b/colors/melange.lua
@@ -364,8 +364,8 @@ for name, attrs in pairs {
   IndentBlanklineSpaceCharBlankline = 'IndentBlanklineChar',
 
   ---- :h cmp-highlight (external plugin) -------------------
-  CmpItemAbbrMatch = { fg = b.yellow },
-  CmpItemAbbrMatchFuzzy = { fg = b.yellow },
+  CmpItemAbbrMatch = { fg = b.yellow, bold = bold },
+  CmpItemAbbrMatchFuzzy = { fg = b.yellow, bold = bold },
   CmpItemKindVariable = '@variable',
   CmpItemKindValue = '@constant',
   CmpItemKindUnit = '@constant',

--- a/colors/melange.lua
+++ b/colors/melange.lua
@@ -362,6 +362,35 @@ for name, attrs in pairs {
   IndentBlanklineChar = 'IblIndent', -- Deprecated?
   IndentBlanklineSpaceChar = 'IndentBlanklineChar',
   IndentBlanklineSpaceCharBlankline = 'IndentBlanklineChar',
+
+  ---- :h cmp-highlight (external plugin) -------------------
+  CmpItemAbbrMatch = { fg = b.yellow },
+  CmpItemAbbrMatchFuzzy = { fg = b.yellow },
+  CmpItemKindVariable = '@variable',
+  CmpItemKindValue = '@constant',
+  CmpItemKindUnit = '@constant',
+  CmpItemKindTypeParameter = '@type',
+  CmpItemKindText = '@text',
+  CmpItemKindStruct = '@type',
+  CmpItemKindSnippet = '@string.special',
+  CmpItemKindReference = '@type',
+  CmpItemKindProperty = '@property',
+  CmpItemKindOperator = '@operator',
+  CmpItemKindModule = '@namespace',
+  CmpItemKindMethod = '@method',
+  CmpItemKindKeyword = '@keyword',
+  CmpItemKindInterface = '@type',
+  CmpItemKindFunction = '@function',
+  CmpItemKindFolder = '@string.special.path',
+  CmpItemKindFile = '@string.special.path',
+  CmpItemKindField = '@field',
+  CmpItemKindEvent = '@type',
+  CmpItemKindEnumMember = '@field',
+  CmpItemKindEnum = '@type',
+  CmpItemKindConstructor = '@constructor',
+  CmpItemKindConstant = '@constant',
+  CmpItemKindColor = '@constant',
+  CmpItemKindClass = '@type',
 } do
   if type(attrs) == 'table' then
     vim.api.nvim_set_hl(0, name, attrs)


### PR DESCRIPTION
<!--
Important:
Supported plugins and terminal emulators must be open source and actively maintained.
If that's not the case, your PR will be closed without comment.
-->

## Checklist for Plugins <!-- Remove if PR is for terminal emulator -->

Paste link to documentation listing highlight groups:

- [x] (In `colors/melange.lua`) Add highlight groups
- [x] (In `README.md`) Add link to plugin source repository

--------------------------------------------------------------------------------
<!-- If there's any additional information you consider relevant, write it here. -->
I added some highlights for the [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) plugin, a fairly popular plugin. The highlights are basically links to the corresponding treesitter groups, which i think is aligned with the targets of this colorscheme. However, some groups where manually picked,i.e. CmpItemAbbrMatch and CmpItemAbbrMatchFuzzy, please feel free to comment on those. Moreover, some groups may need to be adjusted. 
Thanks for the awesome colorscheme and for your time reviewing this PR :)
