### PR TITLE
feat: add new pmenu highlights for matches

### DIFF
--- a/colors/melange.lua
+++ b/colors/melange.lua
@@ -59,6 +59,8 @@ for name, attrs in pairs {
   PmenuSel = { bg = a.sel },
   PmenuSbar = 'Pmenu',
   PmenuThumb = 'PmenuSel',
+  PmenuMatch = { fg = b.yellow, bold = bold, bg = a.float },
+  PmenuMatchSel = { fg = b.yellow, bold = bold, bg = a.sel },
 
   StatusLine = 'NormalFloat',
   StatusLineNC = { fg = a.com, bg = a.float },


### PR DESCRIPTION
This PR adds support for new PmenuMatch and PmenuMatchSel groups that got recently added into nvim, [see](https://github.com/neovim/neovim/pull/29311). The groups are based on #87. I hope this PR helps. 
Thanks for the great colorscheme and effort ! :)


