### PR TITLE
fix: set correctly the FloatTitle and FloatFooter

### DIFF
--- a/colors/melange.lua
+++ b/colors/melange.lua
@@ -34,6 +34,8 @@ for name, attrs in pairs {
 
   Normal = { fg = a.fg, bg = a.bg },
   NormalFloat = { bg = a.float },
+  FloatTitle = { fg = c.yellow, bg = a.float },
+  FloatFooter = { fg = c.yellow, bg = a.float },
   -- NormalNC = {},
 
   -- Cursor = {},


### PR DESCRIPTION
This PR fixes a problem I encountered while messing around with `nvim_open_win()`. Specifically, the background of the title and footer where a little weird and adapted them. If the behavior was intentional feel free to close this PR. Here follows some before and after images:
 
![2024-08-20-23:34:57](https://github.com/user-attachments/assets/fab15e39-6857-4df9-b9b7-975a2a099e72)
![2024-08-20-23:34:18](https://github.com/user-attachments/assets/dae35500-6efb-479d-9156-efb4aeb409f8)

I am totally open to suggestions.