### PR TITLE
Add float border highlights for Neotree

### DIFF
--- a/colors/melange.lua
+++ b/colors/melange.lua
@@ -335,6 +335,7 @@ for name, attrs in pairs {
 
   --- neo-tree highlights  :help neo-tree-highlights ---
 
+  NeoTreeFloatBorder = 'Normal',
   NeoTreeNormal = 'NormalFloat',
   NeoTreeNormalNC = 'NeoTreeNormal',
   NeoTreeVertSplit = { bg = a.bg, fg = a.bg },


### PR DESCRIPTION
<!--
Important:
Supported plugins and terminal emulators must be open source and actively maintained.
If that's not the case, your PR will be closed without comment.
-->

## Checklist for Plugins <!-- Remove if PR is for terminal emulator -->

Paste link to documentation listing highlight groups: https://github.com/nvim-neo-tree/neo-tree.nvim/blob/42caaf5c3b7ca346ab278201151bb878006a6031/doc/neo-tree.txt#L1324

- [x] (In `colors/melange.lua`) Add highlight groups
- [ ] (In `README.md`) Add link to plugin source repository

--------------------------------------------------------------------------------
<!-- If there's any additional information you consider relevant, write it here. -->

Fixes #96 

