### PR TITLE
feat(quickfix): set groups

### DIFF
--- a/colors/melange.lua
+++ b/colors/melange.lua
@@ -64,6 +64,9 @@ for name, attrs in pairs {
   PmenuMatch = { fg = b.yellow, bold = bold, bg = a.float },
   PmenuMatchSel = { fg = b.yellow, bold = bold, bg = a.sel },
 
+  qfFileName = '@string.special.path',
+  QuickFixLine = 'PmenuMatch',
+
   StatusLine = 'NormalFloat',
   StatusLineNC = { fg = a.com, bg = a.float },
   WildMenu = 'NormalFloat',


### PR DESCRIPTION
This PR adds some groups for the default quickfix. The main target is to achieve consistency with other aspects of the colorscheme, since the default behavior feels a bit off. The changes are somewhat opinionated, therefore I am more than open to discussion.  Here are some before and after screenshots:

![2024-12-16T23-07-24](https://github.com/user-attachments/assets/450acd92-9b91-4504-baee-b561f5ff4ce6)

![2024-12-16T23-06-53](https://github.com/user-attachments/assets/5d0bdaf9-b3dc-4a67-8943-b67046e4b01a)
