### PR TITLE
feat(group): set new ComplMatchIns group

### DIFF
--- a/colors/melange.lua
+++ b/colors/melange.lua
@@ -96,6 +96,8 @@ for name, attrs in pairs {
   WarningMsg = { fg = c.red },
   Question = 'MoreMsg',
 
+  ComplMatchIns = 'Comment',
+
   ---- :help :diff -------------------------------------------
 
   DiffAdd = { bg = d.green },


### PR DESCRIPTION
This new group just got merged, [see](https://github.com/neovim/neovim/pull/31628). This groups gives the effect of 'ghost' text, therefore I thought it was appropriate to link it to comments to differentiate it from regular text. I understand this change is a bit opinionated and I am happy to accept suggestions. Here are some before and after screenshots:

![2024-12-19T15-28-00](https://github.com/user-attachments/assets/d77d5b5c-611a-47c0-b3f5-33a7ffb0666d)
![2024-12-19T15-27-28](https://github.com/user-attachments/assets/4d3c88f7-3447-4e6c-b0ca-074358d0ca39)


