### PR TITLE
Added support for Markdown code and code blocks

### DIFF
--- a/colors/melange.lua
+++ b/colors/melange.lua
@@ -338,6 +338,11 @@ for name, attrs in pairs {
   texMathDelim = 'Delimiter',
   texMathEnvArgName = 'PreProc',
 
+  --- markdown syntax highlights (builtin) ---
+
+  markdownCode = { link = 'String' },
+  markdownCodeBlock = { link = 'String' },
+
   --- neo-tree highlights  :help neo-tree-highlights ---
 
   NeoTreeFloatBorder = 'Normal',


### PR DESCRIPTION
This PR concerns the builtin Markdown syntax file. The theme does not provide a specific highlight group for `markdownCode` and `markdownCodeBlock`:

![image](https://github.com/user-attachments/assets/4a7ff1d6-4ac6-4074-82c7-e6779f4dafa0)

Following the practice of some other themes like [iceberg](https://github.com/cocopon/iceberg.vim), I provided a simple link to te `string` highlight group:

![image](https://github.com/user-attachments/assets/efa54dd3-d4e3-4072-a9aa-edb887079159)

Thanks for this excellent theme :slightly_smiling_face: 