### PR TITLE
Add `PmenuKind` highlight group

### DIFF
--- a/colors/melange.lua
+++ b/colors/melange.lua
@@ -58,6 +58,7 @@ for name, attrs in pairs {
   SignColumn = 'LineNr',
 
   Pmenu = 'NormalFloat',
+  PmenuKind = { fg = b.yellow },
   PmenuSel = { bg = a.sel },
   PmenuSbar = 'Pmenu',
   PmenuThumb = 'PmenuSel',


### PR DESCRIPTION
<!--
Important:
Supported plugins and terminal emulators must be open source and actively maintained.
If that's not the case, your PR will be closed without comment.
-->

Fixes https://github.com/savq/melange-nvim/issues/107

Paste link to documentation listing highlight groups:

- [x] (In `colors/melange.lua`) Add highlight groups
- [ ] (In `README.md`) Add link to plugin source repository
 
Added `PmenuKind` to fix the highlighting for [blink.cmp](https://github.com/Saghen/blink.cmp) completion window.

I didn't mark blink.cmp as fully supported in the README, because currently it's using `nvim-cmp`'s groups as a fallback which will be deprecated sometime in the future, so I don't think it really counts as fully supported?